### PR TITLE
tlsa broken too :(

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const server = dnsd.createServer((req, res) => {
   let timeStamp = `[${req.id}/${req.connection.type}] ${req.opcode} ${hostname} ${question.class} ${question.type}`;
   console.time(timeStamp);
   // TODO unsupported due to dnsd's broken implementation.
-  if (question.type == 'AAAA' || 'TLSA') {
+  if (question.type == 'AAAA'||question.type == 'TLSA') {
     console.timeEnd(timeStamp);
     return res.end();
   }

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const server = dnsd.createServer((req, res) => {
   let timeStamp = `[${req.id}/${req.connection.type}] ${req.opcode} ${hostname} ${question.class} ${question.type}`;
   console.time(timeStamp);
   // TODO unsupported due to dnsd's broken implementation.
-  if (question.type == 'AAAA') {
+  if (question.type == 'AAAA' || 'TLSA') {
     console.timeEnd(timeStamp);
     return res.end();
   }


### PR DESCRIPTION
root@localhost:~# dig  @127.0.0.53 _443._tcp.www.nic.cz  IN TLSA

PS C:\app\dns-over-http2-master> node.exe .\index.js 0 53 '127.0.0.53'
[3400/udp4] query _443._tcp.www.nic.cz IN TLSA: 234.891ms
C:\app\dns-over-http2-master\node_modules\dnsd\encode.js:184
        throw new Error('Unsupported record type: ' + JSON.stringify(record))
        ^

Error: Unsupported record type: {"name":"_443._tcp.www.nic.cz.","type":"TLSA","data":"3 1 1 aa7b93daab084536530bd3256e9
eff4557cb43512640f7ab64487dc9ca14fab","ttl":3600,"class":"IN"}
    at State.record (C:\app\dns-over-http2-master\node_modules\dnsd\encode.js:184:15)
    at C:\app\dns-over-http2-master\node_modules\dnsd\encode.js:76:12
    at Array.forEach (native)
    at C:\app\dns-over-http2-master\node_modules\dnsd\encode.js:75:13
    at Array.forEach (native)
    at State.message (C:\app\dns-over-http2-master\node_modules\dnsd\encode.js:73:12)
    at Response.DNSMessage.toBinary (C:\app\dns-over-http2-master\node_modules\dnsd\message.js:139:9)
    at Response.end (C:\app\dns-over-http2-master\node_modules\dnsd\server.js:220:18)
    at Request.request [as _callback](C:appdns-over-http2-masterindex.js:52:9)
    at Request.self.callback (C:\app\dns-over-http2-master\node_modules\request\request.js:187:22)
