### PR TITLE
Add Pointer/PTR query to SupportTypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const request = require('request').defaults({
 const subnet = process.argv[2];
 const RRTypes = require('./RRTypes').IntToString;
 const RRTypesByString = require('./RRTypes').StringToInt;
-const SupportTypes = ['A', 'MX', 'CNAME', 'TXT'];
+const SupportTypes = ['A', 'MX', 'CNAME', 'TXT', 'PTR'];
 
 const server = dnsd.createServer((req, res) => {
   let question = req.question[0], hostname = question.name;


### PR DESCRIPTION
worked well since first i used it yesterday

``````
`root@localhost:~# dig @127.0.0.1 -p 6666 ptr 8.8.8.8.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.6.8.4.0.6.8.4.1.0.0.2.ip6.arpa  +short 
google-public-dns-a.google.com.
`root@localhost:~# dig @127.0.0.1 -p 6666 ptr 4.4.8.8.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.6.8.4.0.6.8.4.1.0.0.2.ip6.arpa  +short 
google-public-dns-b.google.com.

```.` 
``````
