### PR TITLE
pool size, make it configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const option = require('commander')
   .option('-t, --timeout [5000]', 'Default Http Request Timeout', 5000)
   .option('-c, --pool [2]', 'Concurrent Connections of Pool Size ', 2)
   .parse(process.argv);
-if(option.pool<1)option.pool+=1;//No Zero Poolsize
+if(option.pool<1)option.pool++;//No Zero Poolsize
 const defaultOptions = {
   json: true,
   timeout: option.timeout,

--- a/index.js
+++ b/index.js
@@ -10,9 +10,9 @@ const option = require('commander')
   .option('-p, --port [6666]', 'Port to bind', 6666)
   .option('-l, --listen [127.0.0.1]', 'Address to listen', '127.0.0.1')
   .option('-t, --timeout [5000]', 'Default Http Request Timeout', 5000)
-  .option('-p, --pool [2]', 'Default Http Request Timeout', 2)
+  .option('-c, --pool [2]', 'Concurrent Connections of Pool Size ', 2)
   .parse(process.argv);
-
+if(option.pool<1)option.pool+=1;//No Zero Poolsize
 const defaultOptions = {
   json: true,
   timeout: option.timeout,
@@ -66,7 +66,7 @@ class AgentPool {
   }
 }
 
-const agentPool = new AgentPool(2);
+const agentPool = new AgentPool(option.pool);
 
 const request = require('request').defaults(new Proxy(defaultOptions, {
   get: (target, name) => {

--- a/index.js
+++ b/index.js
@@ -9,10 +9,10 @@ const option = require('commander')
   .option('-i, --edns-client-subnet [subnet]', 'EDNS Client Subnet')
   .option('-p, --port [6666]', 'Port to bind', 6666)
   .option('-l, --listen [127.0.0.1]', 'Address to listen', '127.0.0.1')
-  .option('-t, --timeout [5000]', 'Default Http Request Timeout', 5000)
-  .option('-c, --pool [2]', 'Concurrent Connections of Pool Size ', 2)
+  .option('-t, --timeout [5000]', 'Default Http2 Request Timeout', 5000)
+  .option('-c, --pool [2]', 'Concurrent Connections of Pool Size ', val => Math.max(1, val), 2)
   .parse(process.argv);
-if(option.pool<1)option.pool++;//No Zero Poolsize
+
 const defaultOptions = {
   json: true,
   timeout: option.timeout,


### PR DESCRIPTION
Suggestion for making short argv used individual.
//No Zero Poolsize because it makes" Exceed pool maxSockets, creating a new Agent" on every Single request.
