### PR TITLE
Feature: add SupportType SOA state of authority & SRV Server Selection & DS Delegation Signer  query; fix padding length

### DIFF
--- a/h2dns
+++ b/h2dns
@@ -87,7 +87,7 @@ const Constants = require('./dnsd/constants');
 const ip6 = require('ip6');
 
 const subnet = option.ednsClientSubnet;
-const SupportTypes = ['A', 'MX', 'CNAME', 'TXT', 'PTR', 'AAAA', 'NS', 'SOA'];
+const SupportTypes = ['A', 'MX', 'CNAME', 'TXT', 'PTR', 'AAAA', 'NS', 'SOA', 'DS'];
 
 const server = dnsd.createServer((req, res) => {
   let question = req.question[0], hostname = question.name;
@@ -152,8 +152,8 @@ const server = dnsd.createServer((req, res) => {
             rec.data = ip6.normalize(rec.data);
             break;
           case 'SOA':
-        	  rec.data=rec.data.split(/\s+/);
-        	  rec.data= { 
+        	rec.data=rec.data.split(/\s+/);
+        	rec.data= { 
         		'mname': rec.data[0]
               , 'rname': rec.data[1]
               , 'serial': rec.data[2]
@@ -161,10 +161,18 @@ const server = dnsd.createServer((req, res) => {
               , 'retry'  : rec.data[4]
               , 'expire' : rec.data[5]
               , 'ttl'    : rec.data[6]
-              }
+            }
             break;
+          case 'DS':
+          	rec.data=rec.data.split(/\s+/);
+          	rec.data= { 
+          		'key_tag': rec.data[0]
+                , 'algorithm': rec.data[1]
+                , 'digest_type': rec.data[2]
+                , 'digest': rec.data[3]
+              }
+              break;        	
         }
-
         return rec;
       });
     } else if (err) {

--- a/h2dns
+++ b/h2dns
@@ -87,7 +87,7 @@ const Constants = require('./dnsd/constants');
 const ip6 = require('ip6');
 
 const subnet = option.ednsClientSubnet;
-const SupportTypes = ['A', 'MX', 'CNAME', 'TXT', 'PTR', 'AAAA', 'NS'];
+const SupportTypes = ['A', 'MX', 'CNAME', 'TXT', 'PTR', 'AAAA', 'NS', 'SOA'];
 
 const server = dnsd.createServer((req, res) => {
   let question = req.question[0], hostname = question.name;
@@ -102,27 +102,39 @@ const server = dnsd.createServer((req, res) => {
     return res.end();
   }
 
-  // API clients concerned about possible side-channel privacy attacks
-  // using the packet sizes of HTTPS GET requests can use this to make all
-  // requests exactly the same size by padding requests with random data.
+  
   let padding = randomstring.generate({
-    // maximum dnslength+NSEC3PARAM.length (longest possible Type now)
-    // minus current To make always equal query lenght url
-    length: 263 - question.name.length - question.type.length,
+
+	  length: 253 - question.name.length - Constants.type_to_number(question.type).toString().length,
     // safe but can be more extended chars-_
     charset: 'alphanumeric'
   });
-
+  
   let query = {
     name: hostname,
-    type: Constants.type_to_number(question.type),
-    random_padding: padding
+  }
+  
+  if (question.type!='A') {
+	query.type = Constants.type_to_number(question.type);//Type defaults 1
+	// API clients concerned about possible side-channel privacy attacks
+	// using the packet sizes of HTTPS GET requests can use this to make all
+	// requests exactly the same size by padding requests with random data.
+	query.random_padding= randomstring.generate({// 253 maximum dnslength
+	    // +'&type=type'.length minus current Name for equal query length url
+		length: 253 - question.name.length - Constants.type_to_number(question.type).toString().length,
+		charset: 'alphanumeric'
+	})
+  }  
+  else{
+	query.random_padding= randomstring.generate({
+		length: 259 - question.name.length,
+		charset: 'alphanumeric'
+    })
   }
 
   if (subnet) {
     query.edns_client_subnet = subnet;
   }
-
   const http2Req = request({
     url: forwardUrl,
     qs: query
@@ -146,6 +158,18 @@ const server = dnsd.createServer((req, res) => {
           case 'AAAA':
             // dnsd is expecting long IPVersion 6 format
             rec.data = ip6.normalize(rec.data);
+            break;
+          case 'SOA':
+        	  rec.data=rec.data.split(/\s+/);
+        	  rec.data= { 
+        		'mname': rec.data[0]
+              , 'rname': rec.data[1]
+              , 'serial': rec.data[2]
+              , 'refresh': rec.data[3]
+              , 'retry'  : rec.data[4]
+              , 'expire' : rec.data[5]
+              , 'ttl'    : rec.data[6]
+              }
             break;
         }
 

--- a/h2dns
+++ b/h2dns
@@ -87,7 +87,7 @@ const Constants = require('./dnsd/constants');
 const ip6 = require('ip6');
 
 const subnet = option.ednsClientSubnet;
-const SupportTypes = ['A', 'MX', 'CNAME', 'TXT', 'PTR', 'AAAA', 'NS', 'SOA', 'DS'];
+const SupportTypes = ['A', 'MX', 'CNAME', 'TXT', 'PTR', 'AAAA', 'NS', 'SOA', 'SRV', 'DS'];
 
 const server = dnsd.createServer((req, res) => {
   let question = req.question[0], hostname = question.name;
@@ -163,6 +163,15 @@ const server = dnsd.createServer((req, res) => {
               , 'ttl'    : rec.data[6]
             }
             break;
+          case 'SRV':
+          	rec.data=rec.data.split(/\s+/);
+          	rec.data= { 
+          		'priority': rec.data[0]
+                , 'weight': rec.data[1]
+                , 'port': rec.data[2]
+                , 'target': rec.data[3]
+              }
+              break;
           case 'DS':
           	rec.data=rec.data.split(/\s+/);
           	rec.data= { 

--- a/h2dns
+++ b/h2dns
@@ -101,14 +101,6 @@ const server = dnsd.createServer((req, res) => {
     console.timeEnd(timeStamp);
     return res.end();
   }
-
-  
-  let padding = randomstring.generate({
-
-	  length: 253 - question.name.length - Constants.type_to_number(question.type).toString().length,
-    // safe but can be more extended chars-_
-    charset: 'alphanumeric'
-  });
   
   let query = {
     name: hostname,
@@ -122,7 +114,7 @@ const server = dnsd.createServer((req, res) => {
 	query.random_padding= randomstring.generate({// 253 maximum dnslength
 	    // +'&type=type'.length minus current Name for equal query length url
 		length: 253 - question.name.length - Constants.type_to_number(question.type).toString().length,
-		charset: 'alphanumeric'
+		charset: 'alphanumeric'// safe but can be more extended chars-_
 	})
   }  
   else{


### PR DESCRIPTION
dnsd wants soa needs array in formatted to encode.

```
root@localhost:~# dig @127.0.0.1 -p 6666 google.com SOA +short
ns3.google.com. dns-admin.google.com. 137152621 900 900 1800 60
```

> SOA-record for google.com:
>     Primary DNS server = ns4.google.com
>     Responsible person = dns-admin@google.com
>     Serial number = 137152621
>     Refresh interval = 900
>     Retry interval = 900
>     Expire interval = 1800
>     Default / minimum TTL = 60
>     TTL = 3600 (1 hour)
> 
> ```
> root@localhost:~# dig @127.0.0.1 -p 6666 _imaps._tcp.gmail.com SRV +short
> 5 0 993 imap.gmail.com.
> ```
> 
>  SRV-record for _imaps._tcp.gmail.com:
>     Priority = 5
>     Weight = 0
>     Port = 993
>     Target host = imap.gmail.com
>     TTL = 21599 (5 hours, 59 minutes, 59 seconds)

this is used for dnssec.

```
root@localhost:~# dig @127.0.0.1 -p 6666 paypal.com SOA +short
;; Got bad packet: extra input data
108 bytes
d7 2b 81 a0 00 01 00 01 00 00 00 00 06 70 61 79          .+...........pay
70 61 6c 03 63 6f 6d 00 00 2b 00 01 c0 0c 00 2b          pal.com..+.....+
00 01 00 00 1b 17 00 44 52 2d 05 02 30 44 46 31          .......DR-..0DF1
37 42 32 38 35 35 34 39 35 34 44 38 31 39 45 30          7B28554954D819E0
43 45 45 41 42 39 38 46 43 46 43 44 35 36 35 37          CEEAB98FCFCD5657
32 41 34 43 46 34 46 35 35 31 46 30 41 39 42 45          2A4CF4F551F0A9BE
36 44 30 34 44 42 32 46 36 35 43 33                      6D04DB2F65C3

```

> Answer section:
> DS-record for paypal.com:
>     Key tag: 21037
>     Algorithm: 5 (RSA/SHA-1)
>     Digest type: 2
>     Digest: 30444631374232383535343935344438313945304345454142393846434643443536353732413443463446353531463041394245364430344442324636354333
>     TTL = 11007 (3 hours, 3 minutes, 27 seconds)

padding:
before i missed the fact that type is submitted in digit not constant. wich is fine. Both is accepted from google. no need to supply type at all if it is a "A" record because it always assumes this by default. Even if not set.. So i do not append it in query parameters now.

_without subnet manually set, i get length of 280 equal for all types supported and domain now! 
verified checked by:

```
 ``
 console.log('length:%s query:%s',http2Req.url.query.length,http2Req.url.query)
line 141 after (err, response, output) => {
``
```

_
