### PR TITLE
fix: timeout argv; Respond to Unsupported Type with: Server failed to complete the DNS request. Feature: make Internet Protocol Version configurable

### DIFF
--- a/h2dns
+++ b/h2dns
@@ -26,6 +26,7 @@ const option = require('commander')
   .option('--ping-interval [60000]',
     'Interval of ping to keep connection alive.',
      val => Math.max(500, val), 60000) // at least 500ms?
+  .option('-v, --IPv [6]', 'Force Resolver Internet Protocol Version priority', 0)//4||6;Zero respects OS decision
   .parse(process.argv);
 
 const defaultOptions = {
@@ -34,7 +35,7 @@ const defaultOptions = {
   gzip: true,
   agent: true, // a holder for proxy
 };
-
+resolver.family=parseInt(option.IPv);
 const agentPool = require('./pool')(resolver, option.pool);
 
 const request = require('request').defaults(new Proxy(defaultOptions, {

--- a/h2dns
+++ b/h2dns
@@ -19,7 +19,7 @@ const option = require('commander')
   .option('-i, --edns-client-subnet [subnet]', 'EDNS Client Subnet')
   .option('-p, --port [6666]', 'Port to bind', 6666)
   .option('-l, --listen [127.0.0.1]', 'Address to listen', '127.0.0.1')
-  .option('-t, --timeout [5000]', 'Default Http2 Request Timeout', 5000)
+  .option('-t, --timeout [5000]', 'Default Http2 Request Timeout', parseInt, 5000)
   .option('-c, --pool [2]',
     'Concurrent Connections of Pool Size ',
      val => Math.max(1, val), 2)

--- a/h2dns
+++ b/h2dns
@@ -19,7 +19,7 @@ const option = require('commander')
   .option('-i, --edns-client-subnet [subnet]', 'EDNS Client Subnet')
   .option('-p, --port [6666]', 'Port to bind', 6666)
   .option('-l, --listen [127.0.0.1]', 'Address to listen', '127.0.0.1')
-  .option('-t, --timeout [5000]', 'Default Http2 Request Timeout', parseInt, 5000)
+  .option('-t, --timeout [5000]', 'Default Http2 Request Timeout', 5000)
   .option('-c, --pool [2]',
     'Concurrent Connections of Pool Size ',
      val => Math.max(1, val), 2)
@@ -30,7 +30,7 @@ const option = require('commander')
 
 const defaultOptions = {
   json: true,
-  timeout: option.timeout,
+  timeout: parseInt(option.timeout),
   gzip: true,
   agent: true, // a holder for proxy
 };

--- a/h2dns
+++ b/h2dns
@@ -64,6 +64,7 @@ const server = dnsd.createServer((req, res) => {
   // TODO unsupported due to dnsd's broken implementation.
   if (SupportTypes.indexOf(question.type) === -1) {
     console.timeEnd(timeStamp);
+    res.responseCode=2;//SERVFAIL Server failed to complete the DNS request
     return res.end();
   }
 

--- a/pool.js
+++ b/pool.js
@@ -38,7 +38,8 @@ class AgentPool {
   createAgent() {
     const agent = spdy.createAgent({
       host: this.resolver.hostname,
-      port: this.resolver.port
+      port: this.resolver.port,
+      family: this.resolver.family
     });
     agent.on('error', err => {
       debug('agent error', err);


### PR DESCRIPTION
instead of responseStatuscode:0 (NOERROR) with empty answer. That could be interpreted As „nxDomain“ from Application while it's Not.

node .\h2dns -t 5000
node .\h2dns --timeout 5000

```

TypeError: "msecs" argument must be a number
    at Object.exports.enroll (timers.js:298:11)
    at Socket.setTimeout (net.js:330:12)
    at ClientRequest.<anonymous> (_http_client.js:642:10)
    at emitOne (events.js:101:20)
    at ClientRequest.emit (events.js:188:7)
    at tickOnSocket (_http_client.js:567:7)
    at onSocketNT (_http_client.js:579:5)
---------------------------------------------
    at ClientRequest.setTimeout (_http_client.js:641:8)
    at Request.start (C:\app\yyfrankyy\node_modules\request\request.js:773:16)
    at Request.end (C:\app\yyfrankyy\node_modules\request\request.js:1398:10)
    at end (C:\app\yyfrankyy\node_modules\request\request.js:567:14)
    at Immediate.<anonymous> (C:\app\yyfrankyy\node_modules\request\request.js:581:7)
    at runCallback (timers.js:637:20)
    at tryOnImmediate (timers.js:610:5)
    at processImmediate [as _immediateCallback] (timers.js:582:5)
```

parseInt
